### PR TITLE
[Fix] Fix CI check for Draft PR

### DIFF
--- a/.github/workflows/build_unit_test.yaml
+++ b/.github/workflows/build_unit_test.yaml
@@ -7,26 +7,27 @@ on:
     paths-ignore:
       - ".github/**.md"
       - "README.md"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  fail_if_pull_request_is_draft:
-    if: github.event.pull_request.draft == true
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
-      run: exit 1
-
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
+    - name: Fail if draft
+      if: github.event.pull_request.draft == true
+      run:
+        exit 1
+
     - name: checkout
       uses: actions/checkout@v2
 

--- a/.github/workflows/build_unit_test.yaml
+++ b/.github/workflows/build_unit_test.yaml
@@ -15,6 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fail_if_pull_request_is_draft:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
+      run: exit 1
+      
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/build_unit_test.yaml
+++ b/.github/workflows/build_unit_test.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Fail if draft
-      if: github.event.pull_request.draft
+      if: github.event.pull_request.draft == true
       run:
         exit 1
 

--- a/.github/workflows/build_unit_test.yaml
+++ b/.github/workflows/build_unit_test.yaml
@@ -7,8 +7,6 @@ on:
     paths-ignore:
       - ".github/**.md"
       - "README.md"
-    types: [review_requested, ready_for_review]
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +21,7 @@ jobs:
     steps:
     - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
       run: exit 1
-      
+
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/build_unit_test.yaml
+++ b/.github/workflows/build_unit_test.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Fail if draft
-      if: github.event.pull_request.draft == true
+      if: github.event.pull_request.draft
       run:
         exit 1
 

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -27,5 +27,5 @@ jobs:
       if: github.event.pull_request.draft == true
       run:
         exit 1
-    - name: Paas
+    - name: Pass
       run: 'echo "No build required" '

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -13,18 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fail_if_pull_request_is_draft:
-    if: github.event.pull_request.draft == true
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
-      run: exit 1
-
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-     - run: 'echo "No build required" '
+      - run: 'echo "No build required" '

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -7,8 +7,6 @@ on:
     paths:
       - ".github/**.md"
       - "README.md"
-    types: [review_requested, ready_for_review]
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +21,7 @@ jobs:
     steps:
     - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
       run: exit 1
-      
+
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Fail if draft
-      if: github.event.pull_request.draft
+      if: github.event.pull_request.draft == true
       run:
         exit 1
     - name: Paas

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -15,6 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  fail_if_pull_request_is_draft:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
+      run: exit 1
+      
   unit_test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Fail if draft
-      if: github.event.pull_request.draft == true
+      if: github.event.pull_request.draft
       run:
         exit 1
     - name: Paas

--- a/.github/workflows/build_unit_test_pass.yaml
+++ b/.github/workflows/build_unit_test_pass.yaml
@@ -7,6 +7,11 @@ on:
     paths:
       - ".github/**.md"
       - "README.md"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,4 +23,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - run: 'echo "No build required" '
+    - name: Fail if draft
+      if: github.event.pull_request.draft == true
+      run:
+        exit 1
+    - name: Paas
+      run: 'echo "No build required" '


### PR DESCRIPTION
https://github.com/orgs/community/discussions/25722

Skipping CI is recognized as a success. 
So when skipping CI, make failure instead.