### PR TITLE
Support custom trainer and backend

### DIFF
--- a/siatune/mm/tasks/mmtrainbase.py
+++ b/siatune/mm/tasks/mmtrainbase.py
@@ -65,6 +65,9 @@ class MMTrainBasedTask(BaseTask, metaclass=ABCMeta):
         Returns:
             TorchTrainer: The trainable task.
         """
+        assert self.num_workers == self.num_gpus_per_worker, (
+            '`num_workers` must be equal to `num_gpus_per_worker`.')
+
         return DataParallelTrainer(
             self.context_aware_run,
             backend_config=CustomBackendConfig(),

--- a/siatune/mm/tasks/mmtrainbase.py
+++ b/siatune/mm/tasks/mmtrainbase.py
@@ -4,8 +4,9 @@ from abc import ABCMeta, abstractmethod
 import mmcv
 import torch
 from ray.air.config import ScalingConfig
-from ray.train.torch import TorchConfig, TorchTrainer
+from ray.train.data_parallel_trainer import DataParallelTrainer
 
+from siatune.ray.config import CustomBackendConfig
 from .base import BaseTask
 from .builder import TASKS
 
@@ -54,7 +55,7 @@ class MMTrainBasedTask(BaseTask, metaclass=ABCMeta):
         """
         pass
 
-    def create_trainable(self) -> TorchTrainer:
+    def create_trainable(self) -> DataParallelTrainer:
         """Get ray trainable task.
 
         Args:
@@ -64,12 +65,12 @@ class MMTrainBasedTask(BaseTask, metaclass=ABCMeta):
         Returns:
             TorchTrainer: The trainable task.
         """
-        return TorchTrainer(
+        return DataParallelTrainer(
             self.context_aware_run,
+            backend_config=CustomBackendConfig(),
             scaling_config=ScalingConfig(
                 trainer_resources=dict(
                     CPU=self.num_cpus_per_worker,
                     GPU=self.num_gpus_per_worker),
                 num_workers=self.num_workers,
-                use_gpu=torch.cuda.is_available()),
-            torch_config=TorchConfig(backend='gloo'))
+                use_gpu=torch.cuda.is_available()))

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -1,0 +1,71 @@
+# Copyright (c) SI-Analytics. All rights reserved.
+import logging
+import os
+from dataclasses import dataclass
+
+import ray
+import torch.distributed as dist
+from ray.train._internal.utils import get_address_and_port
+from ray.train._internal.worker_group import WorkerGroup
+from ray.train.backend import BackendConfig
+from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
+from ray.train.torch.config import _TorchBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CustomBackendConfig(BackendConfig):
+    """Configuration for torch process group setup."""
+
+    @property
+    def backend_cls(self):
+        return _CustomTorchBackend
+
+
+def _set_nccl_network_interface() -> str:
+    """Set the appropriate NCCL network interface to use."""
+
+    if 'NCCL_SOCKET_IFNAME' not in os.environ:
+        logger.debug(
+            f'Setting NCCL_SOCKET_IFNAME to {DEFAULT_NCCL_SOCKET_IFNAME} '
+            'to prioritize ethernet connection. To override this behavior, '
+            'set the `NCCL_SOCKET_IFNAME` environment variable in your Ray '
+            'runtime environment: '
+            "`ray.init(runtime_env={{'env_vars': {'NCCL_SOCKET_IFNAME': 'ens5'}})`"  # noqa
+        )
+        os.environ['NCCL_SOCKET_IFNAME'] = DEFAULT_NCCL_SOCKET_IFNAME
+
+
+class _CustomTorchBackend(_TorchBackend):
+    share_cuda_visible_devices: bool = True
+
+    def on_start(self, worker_group: WorkerGroup,
+                 backend_config: BackendConfig):
+        if dist.is_available():
+            if 'NCCL_SOCKET_IFNAME' in os.environ:
+                worker_group.execute(_set_nccl_network_interface)
+
+            master_addr, master_port = worker_group.execute_single(
+                0, get_address_and_port)
+
+            def set_env_vars(addr, port, rank, world_size):
+                os.environ['MASTER_ADDR'] = addr
+                os.environ['MASTER_PORT'] = str(port)
+                os.environ['RANK'] = str(rank)
+                os.environ['WORLD_SIZE'] = str(world_size)
+
+            setup_futures = []
+            for i in range(len(worker_group)):
+                setup_futures.append(
+                    worker_group.execute_single_async(
+                        i,
+                        set_env_vars,
+                        addr=master_addr,
+                        port=master_port,
+                        rank=i,
+                        world_size=len(worker_group),
+                    ))
+            ray.get(setup_futures)
+        else:
+            raise RuntimeError('Distributed torch is not available.')

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -12,7 +12,7 @@ from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import BackendConfig
 from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
-from ray.train.torch.config import _TorchBackend
+from ray.train.torch.config import _TorchBackend, _set_nccl_network_interface
 
 logger = logging.getLogger(__name__)
 
@@ -24,20 +24,6 @@ class CustomBackendConfig(BackendConfig):
     @property
     def backend_cls(self):
         return _CustomTorchBackend
-
-
-def _set_nccl_network_interface():
-    """Set the appropriate NCCL network interface to use."""
-
-    if 'NCCL_SOCKET_IFNAME' not in os.environ:
-        logger.debug(
-            f'Setting NCCL_SOCKET_IFNAME to {DEFAULT_NCCL_SOCKET_IFNAME} '
-            'to prioritize ethernet connection. To override this behavior, '
-            'set the `NCCL_SOCKET_IFNAME` environment variable in your Ray '
-            'runtime environment: '
-            "`ray.init(runtime_env={{'env_vars': {'NCCL_SOCKET_IFNAME': 'ens5'}})`"  # noqa
-        )
-        os.environ['NCCL_SOCKET_IFNAME'] = DEFAULT_NCCL_SOCKET_IFNAME
 
 
 class _CustomTorchBackend(_TorchBackend):

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -1,6 +1,5 @@
 # Copyright (c) SI-Analytics. All rights reserved.
 # Modified from https://github.com/ray-project/ray/blob/ray-2.1.0/python/ray/train/torch/config.py  # noqa
-# for applying MM based repo training
 
 import logging
 import os

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -1,4 +1,7 @@
 # Copyright (c) SI-Analytics. All rights reserved.
+# Modified from https://github.com/ray-project/ray/blob/ray-2.1.0/python/ray/train/torch/config.py  # noqa
+# for applying MM based repo training
+
 import logging
 import os
 from dataclasses import dataclass

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -11,8 +11,7 @@ import torch.distributed as dist
 from ray.train._internal.utils import get_address_and_port
 from ray.train._internal.worker_group import WorkerGroup
 from ray.train.backend import BackendConfig
-from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
-from ray.train.torch.config import _TorchBackend, _set_nccl_network_interface
+from ray.train.torch.config import _set_nccl_network_interface, _TorchBackend
 
 logger = logging.getLogger(__name__)
 

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -26,7 +26,7 @@ class CustomBackendConfig(BackendConfig):
         return _CustomTorchBackend
 
 
-def _set_nccl_network_interface() -> str:
+def _set_nccl_network_interface():
     """Set the appropriate NCCL network interface to use."""
 
     if 'NCCL_SOCKET_IFNAME' not in os.environ:
@@ -45,30 +45,30 @@ class _CustomTorchBackend(_TorchBackend):
 
     def on_start(self, worker_group: WorkerGroup,
                  backend_config: BackendConfig):
-        if dist.is_available():
-            if 'NCCL_SOCKET_IFNAME' in os.environ:
-                worker_group.execute(_set_nccl_network_interface)
-
-            master_addr, master_port = worker_group.execute_single(
-                0, get_address_and_port)
-
-            def set_env_vars(addr, port, rank, world_size):
-                os.environ['MASTER_ADDR'] = addr
-                os.environ['MASTER_PORT'] = str(port)
-                os.environ['RANK'] = str(rank)
-                os.environ['WORLD_SIZE'] = str(world_size)
-
-            setup_futures = []
-            for i in range(len(worker_group)):
-                setup_futures.append(
-                    worker_group.execute_single_async(
-                        i,
-                        set_env_vars,
-                        addr=master_addr,
-                        port=master_port,
-                        rank=i,
-                        world_size=len(worker_group),
-                    ))
-            ray.get(setup_futures)
-        else:
+        if not dist.is_available():
             raise RuntimeError('Distributed torch is not available.')
+
+        worker_group.execute(_set_nccl_network_interface)
+
+        master_addr, master_port = worker_group.execute_single(
+            0, get_address_and_port)
+
+        def set_env_vars(addr, port, rank, world_size):
+            os.environ['MASTER_ADDR'] = addr
+            os.environ['MASTER_PORT'] = str(port)
+            os.environ['RANK'] = str(rank)
+            os.environ['LOCAL_RANK'] = str(rank)
+            os.environ['WORLD_SIZE'] = str(world_size)
+
+        setup_futures = []
+        for i in range(len(worker_group)):
+            setup_futures.append(
+                worker_group.execute_single_async(
+                    i,
+                    set_env_vars,
+                    addr=master_addr,
+                    port=master_port,
+                    rank=i,
+                    world_size=len(worker_group),
+                ))
+        ray.get(setup_futures)

--- a/siatune/ray/config.py
+++ b/siatune/ray/config.py
@@ -41,7 +41,6 @@ def _set_nccl_network_interface():
 
 
 class _CustomTorchBackend(_TorchBackend):
-    share_cuda_visible_devices: bool = True
 
     def on_start(self, worker_group: WorkerGroup,
                  backend_config: BackendConfig):

--- a/tests/test_mm/test_tasks.py
+++ b/tests/test_mm/test_tasks.py
@@ -273,7 +273,7 @@ def test_mm_train_based_task(mock_report):
             )))
 
     task = TestTask()
-    task.set_resource(1, 0, 1)
+    task.set_resource()
     task.context_aware_run(searched_cfg=dict(cfg=cfg))
     assert 'loss' in get_session()
 


### PR DESCRIPTION
### Motivation
Since MM-based repositories already use `torch.distributed.init_process_group`, using `TorchTrainer` for DDP in ray framework causes the `RuntimeError("trying to initialize the default process group twice!")`.
To solve this problem, I introduced a custom backend modified from [here](https://github.com/ray-project/ray/blob/ray-2.1.0/python/ray/train/torch/config.py).