### PR TITLE
[Fix] Install scikit-learn instead of deprecated sklearn

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,5 +4,5 @@ hyperopt==0.2.5
 mlflow==1.23.1
 nevergrad==0.4.3.post7
 optuna==2.10.0
+scikit-learn
 scikit-optimize==0.9.0
-sklearn


### PR DESCRIPTION
## Motivation

```bash
× python setup.py egg_info did not run successfully.
[47](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:48)
  │ exit code: 1
[48](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:49)
  ╰─> [18 lines of output]
[49](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:50)
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
[50](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:51)
      rather than 'sklearn' for pip commands.
[51](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:52)
      
[52](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:53)
      Here is how to fix this error in the main use cases:
[53](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:54)
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
[54](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:55)
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
[55](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:56)
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
[56](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:57)
      - if the 'sklearn' package is used by one of your dependencies,
[57](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:58)
        it would be great if you take some time to track which package uses
[58](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:59)
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
[59](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:60)
      - as a last resort, set the environment variable
[60](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:61)
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
[61](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:62)
      
[62](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:63)
      More information is available at
[63](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:64)
      https://github.com/scikit-learn/sklearn-pypi-package
[64](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:65)
      
[65](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:66)
      If the previous advice does not cover your use case, feel free to report it at
[66](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:67)
      https://github.com/scikit-learn/sklearn-pypi-package/issues/new
[67](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:68)
      [end of output]
[68](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:69)
  
[69](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:70)
  note: This error originates from a subprocess, and is likely not a problem with pip.
[70](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:71)
error: metadata-generation-failed
[71](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:72)

[72](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:73)
× Encountered error while generating package metadata.
[73](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:74)
╰─> See above for output.
[74](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:75)

[75](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:76)
note: This is an issue with the package mentioned above, not pip.
[76](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:77)
hint: See above for details.
[77](https://github.com/SIAnalytics/siatune/actions/runs/3702550299/jobs/6272960697#step:7:78)
Error: Process completed with exit code 1.
```