### PR TITLE
Support resume

### DIFF
--- a/siatune/ray/tuner.py
+++ b/siatune/ray/tuner.py
@@ -35,6 +35,7 @@ class Tuner:
         trial_scheduler=None,
         stopper=None,
         callbacks=None,
+        resume=None,
     ):
         work_dir = osp.abspath(work_dir)
 
@@ -56,6 +57,8 @@ class Tuner:
             if isinstance(callbacks, dict):
                 callbacks = [callbacks]
             callbacks = [build_callback(callback) for callback in callbacks]
+
+        self.resume = resume
 
         self.tuner = RayTuner(
             trainable,
@@ -84,13 +87,13 @@ class Tuner:
             trial_scheduler=cfg.get('trial_scheduler', None),
             stopper=cfg.get('stopper', None),
             callbacks=cfg.get('callbacks', None),
+            resume=cfg.get('resume', None),
         )
 
         return tuner
 
-    @classmethod
-    def resume(cls, path, **kwargs):
-        return cls.restore(path, **kwargs)
-
     def fit(self):
+        if self.resume is not None:
+            return self.tuner.restore(self.resume)
+
         return self.tuner.fit()

--- a/siatune/ray/tuner.py
+++ b/siatune/ray/tuner.py
@@ -1,6 +1,7 @@
 # Copyright (c) SI-Analytics. All rights reserved.
 import copy
 import os.path as osp
+from typing import Optional
 
 from ray.air.config import RunConfig
 from ray.tune.tune_config import TuneConfig
@@ -23,6 +24,8 @@ class Tuner:
         trial_scheduler (dict, optional):
         stopper (dict, optional):
         callbacks (list, optional):
+        resume (str, optional): The experiment path to resume.
+            Defaults to None.
     """
 
     def __init__(
@@ -35,7 +38,7 @@ class Tuner:
         trial_scheduler=None,
         stopper=None,
         callbacks=None,
-        resume=None,
+        resume: Optional[str] = None,
     ):
         work_dir = osp.abspath(work_dir)
 

--- a/siatune/ray/tuner.py
+++ b/siatune/ray/tuner.py
@@ -94,6 +94,6 @@ class Tuner:
 
     def fit(self):
         if self.resume is not None:
-            return self.tuner.restore(self.resume)
+            self.tuner = RayTuner.restore(self.resume)
 
         return self.tuner.fit()

--- a/siatune/run.py
+++ b/siatune/run.py
@@ -22,13 +22,7 @@ def parse_args() -> Namespace:
     parser.add_argument(
         '--work-dir', default=None, help='the dir to save logs and models')
     parser.add_argument(
-        '--resume',
-        nargs='?',
-        type=str,
-        const='auto',
-        help='If specify checkpoint path, resume from it, while if not '
-        'specify, try to auto resume from the latest checkpoint '
-        'in the work directory.')
+        '--resume', default=None, help='the experiment path to resume')
     parser.add_argument(
         '--address',
         default=None,

--- a/siatune/run.py
+++ b/siatune/run.py
@@ -22,6 +22,14 @@ def parse_args() -> Namespace:
     parser.add_argument(
         '--work-dir', default=None, help='the dir to save logs and models')
     parser.add_argument(
+        '--resume',
+        nargs='?',
+        type=str,
+        const='auto',
+        help='If specify checkpoint path, resume from it, while if not '
+        'specify, try to auto resume from the latest checkpoint '
+        'in the work directory.')
+    parser.add_argument(
         '--address',
         default=None,
         help='the address of the ray cluster to connect to',
@@ -88,6 +96,9 @@ def main() -> None:
     # work_dir in task is overridden with work_dir in tune
     if hasattr(task_processor.args, 'work_dir'):
         task_processor.args.work_dir = tune_config.work_dir
+
+    if args.resume is not None:
+        tune_config.resume = args.resume
 
     ray.init(
         address=args.address, num_cpus=args.num_cpus, num_gpus=args.num_gpus)


### PR DESCRIPTION
Refer to [this documentation](https://docs.ray.io/en/latest/tune/tutorials/tune-stopping.html).

### Before resume
```bash
python3 tools/tune.py /some/path/configs/mmseg/mmseg_asynchb_nevergrad_pso.py \
    --work-dir /some/path/resume \
    --trainable-args /some/path/configs/mmseg/upernet_deit-s16_mln_512x512_160k_ade20k/upernet_deit-s16_mln_512x512_160k_ade20k.py 
```
```
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
| Trial name                   | status     | loc                 |   train_loop_config/da | train_loop_config/mo   | train_loop_config/op   |   iter |   total time (s) |   train/decode.loss_ce |   train/decode.acc_seg |   train/aux.loss_ce |
|                              |            |                     |     ta.samples_per_gpu | del                    | timizer                |        |                  |                        |                        |                     |
|------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------|
| DataParallelTrainer_0fa9d588 | RUNNING    | 10.244.28.73:938824 |                      4 | segformer_mit_b0       | rms                    |        |                  |                        |                        |                     |
| DataParallelTrainer_180398c2 | PENDING    |                     |                      3 | fpn_r50                | adam                   |        |                  |                        |                        |                     |
| DataParallelTrainer_de27d74e | TERMINATED | 10.244.28.73:933838 |                      2 | pspnet_r50_d8          | sgd                    |     16 |          25.6659 |                1.88792 |               15.8528  |            0.768364 |
| DataParallelTrainer_e38bbc50 | TERMINATED | 10.244.28.73:935913 |                      5 | pspnet_r50_d8          | sgd                    |     16 |          29.3023 |                2.13874 |                7.31824 |            0.853498 |
| DataParallelTrainer_daf738da | ERROR      | 10.244.28.73:932999 |                      5 | segformer_mit_b0       | adam                   |        |                  |                        |                        |                     |
| DataParallelTrainer_fc0fbb96 | ERROR      | 10.244.28.73:937999 |                      4 | fpn_r50                | adamw                  |        |                  |                        |                        |                     |
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
```

### After resume
```bash
python3 tools/tune.py /some/path/configs/mmseg/mmseg_asynchb_nevergrad_pso.py \
    --resume /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49 \
    --trainable-args /some/path/configs/mmseg/upernet_deit-s16_mln_512x512_160k_ade20k/upernet_deit-s16_mln_512x512_160k_ade20k.py 
```
```
2022-12-17 06:11:20,786 INFO worker.py:1525 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265 
2022-12-17 06:11:22,241 INFO experiment_analysis.py:796 -- No `self.trials`. Drawing logdirs from checkpoint file. This may result in some information that is out of sync, as checkpointing is periodic.
2022-12-17 06:11:22,307 INFO tensorboardx.py:170 -- pip install "ray[tune]" to see TensorBoard files.
2022-12-17 06:11:22,307 WARNING callback.py:109 -- The TensorboardX logger cannot be instantiated because either TensorboardX or one of it's dependencies is not installed. Please make sure you have the latest version of TensorboardX installed: `pip install -U tensorboardx`
2022-12-17 06:11:22,309 INFO trial_runner.py:602 -- A local experiment checkpoint was found and will be used to restore the previous experiment state.
2022-12-17 06:11:22,309 INFO trial_runner.py:738 -- Using following checkpoint to resume: /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49/experiment_state-2022-12-17_06-05-49.json
2022-12-17 06:11:22,311 WARNING trial_runner.py:749 -- Attempting to resume experiment from /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49. This will ignore any new changes to the specification.
2022-12-17 06:11:22,334 INFO trial.py:178 -- Creating a new dirname DataParallelTrainer_180398c2_6_data_samples_per_gpu=3,model=fpn_r50,model_auxiliary_head_num_classes=21,model_decode_head_num_clas_2022-12-17_06-11-22_287f because trial dirname 'DataParallelTrainer_180398c2_6_data_samples_per_gpu=3,model=fpn_r50,model_auxiliary_head_num_classes=21,model_decode_head_num_clas_2022-12-17_06-11-22' already exists.
2022-12-17 06:11:22,336 INFO tune.py:669 -- TrialRunner resumed, ignoring new add_experiment but updating trial resources.
(TrainTrainable pid=944290) No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
(TrainTrainable pid=944290) /usr/local/lib/python3.7/site-packages/nevergrad/optimization/differentialevolution.py:107: InefficientSettingsWarning: DE algorithms are inefficient with budget < 60
(TrainTrainable pid=944290)   "DE algorithms are inefficient with budget < 60", base.errors.InefficientSettingsWarning
== Status ==
Current time: 2022-12-17 06:11:22 (running for 00:00:00.20)
Memory usage on this node: 95.6/1510.1 GiB 
Using FIFO scheduling algorithm.
Resources requested: 1.0/10 CPUs, 1.0/1 GPUs, 0.0/16.06 GiB heap, 0.0/8.03 GiB objects (0.0/1.0 accelerator_type:V100)
Current best trial: de27d74e with train/loss=2.656280040740967 and parameters={'train_loop_config': {'data.samples_per_gpu': 2, 'model': pspnet_r50_d8, 'model.decode_head.num_classes': 21, 'model.auxiliary_head.num_classes': 21, 'optimizer': sgd}}
Result logdir: /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49
Number of trials: 6 (2 ERROR, 1 PENDING, 1 RUNNING, 2 TERMINATED)
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
| Trial name                   | status     | loc                 |   train_loop_config/da | train_loop_config/mo   | train_loop_config/op   |   iter |   total time (s) |   train/decode.loss_ce |   train/decode.acc_seg |   train/aux.loss_ce |
|                              |            |                     |     ta.samples_per_gpu | del                    | timizer                |        |                  |                        |                        |                     |
|------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------|
| DataParallelTrainer_0fa9d588 | RUNNING    | 10.244.28.73:944290 |                      4 | segformer_mit_b0       | rms                    |        |                  |                        |                        |                     |
| DataParallelTrainer_180398c2 | PENDING    |                     |                      3 | fpn_r50                | adam                   |        |                  |                        |                        |                     |
| DataParallelTrainer_e38bbc50 | TERMINATED | 10.244.28.73:935913 |                      5 | pspnet_r50_d8          | sgd                    |     16 |          29.3023 |                2.13874 |                7.31824 |            0.853498 |
| DataParallelTrainer_de27d74e | TERMINATED | 10.244.28.73:933838 |                      2 | pspnet_r50_d8          | sgd                    |     16 |          25.6659 |                1.88792 |               15.8528  |            0.768364 |
| DataParallelTrainer_daf738da | ERROR      |                     |                      5 | segformer_mit_b0       | adam                   |        |                  |                        |                        |                     |
| DataParallelTrainer_fc0fbb96 | ERROR      |                     |                      4 | fpn_r50                | adamw                  |        |                  |                        |                        |                     |
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
Number of errored trials: 2
+------------------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Trial name                   |   # failures | error file                                                                                                                                                                                                                                                        |
|------------------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| DataParallelTrainer_daf738da |            1 | /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49/DataParallelTrainer_daf738da_1_data_samples_per_gpu=5,model=segformer_mit_b0,model_auxiliary_head_num_classes=21,model_decode_head_2022-12-17_06-05-50/error.txt |
| DataParallelTrainer_fc0fbb96 |            1 | /some/path/resume/DataParallelTrainer_2022-12-17_06-05-49/DataParallelTrainer_fc0fbb96_4_data_samples_per_gpu=4,model=fpn_r50,model_auxiliary_head_num_classes=21,model_decode_head_num_clas_2022-12-17_06-07-18/error.txt |
+------------------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
```
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
| Trial name                   | status     | loc                 |   train_loop_config/da | train_loop_config/mo   | train_loop_config/op   |   iter |   total time (s) |   train/decode.loss_ce |   train/decode.acc_seg |   train/aux.loss_ce |
|                              |            |                     |     ta.samples_per_gpu | del                    | timizer                |        |                  |                        |                        |                     |
|------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------|
| DataParallelTrainer_e38bbc50 | TERMINATED | 10.244.28.73:935913 |                      5 | pspnet_r50_d8          | sgd                    |     16 |          29.3023 |                2.13874 |                7.31824 |            0.853498 |
| DataParallelTrainer_de27d74e | TERMINATED | 10.244.28.73:933838 |                      2 | pspnet_r50_d8          | sgd                    |     16 |          25.6659 |                1.88792 |               15.8528  |            0.768364 |
| DataParallelTrainer_daf738da | ERROR      |                     |                      5 | segformer_mit_b0       | adam                   |        |                  |                        |                        |                     |
| DataParallelTrainer_fc0fbb96 | ERROR      |                     |                      4 | fpn_r50                | adamw                  |        |                  |                        |                        |                     |
| DataParallelTrainer_0fa9d588 | ERROR      | 10.244.28.73:944290 |                      4 | segformer_mit_b0       | rms                    |        |                  |                        |                        |                     |
| DataParallelTrainer_180398c2 | ERROR      | 10.244.28.73:945140 |                      3 | fpn_r50                | adam                   |        |                  |                        |                        |                     |
+------------------------------+------------+---------------------+------------------------+------------------------+------------------------+--------+------------------+------------------------+------------------------+---------------------+
```