### PR TITLE
Replace `ray[default]` with `ray[tune]`

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,1 @@
-pandas
-protobuf<=3.20
-pyarrow
 ray[tune]==2.1.0
-tabulate

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,2 @@
-pyarrow
+ray[data]==2.1.0
 ray[tune]==2.1.0

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 pandas
 protobuf<=3.20
 pyarrow
-ray[default]==2.1.0
+ray[tune]==2.1.0
 tabulate

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,1 +1,2 @@
+pyarrow
 ray[tune]==2.1.0


### PR DESCRIPTION
## Motivation

To install dependencies for Ray Tune, we need to use `pip install -U 'ray[tune]'` script instead of `pip install 'ray[default]'` script.
Refer to this [docs](https://docs.ray.io/en/latest/ray-overview/installation.html) and this [code](https://github.com/ray-project/ray/blob/ray-2.1.0/python/setup.py) for details.

### TODO
- [x] Test `tools/tune.py` script

## Modification

Please briefly describe what modification is made in this PR.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
