### PR TITLE
Bump ray from v2.1.0 to v2.2.0

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,2 @@
-ray[data]==2.1.0
-ray[tune]==2.1.0
+ray[data]==2.2.0
+ray[tune]==2.2.0

--- a/siatune/tune/tuner.py
+++ b/siatune/tune/tuner.py
@@ -75,7 +75,10 @@ class Tuner:
             trainable,
             param_space=dict(train_loop_config=param_space),
             tune_config=TuneConfig(
-                search_alg=searcher, scheduler=trial_scheduler, **tune_cfg),
+                search_alg=searcher,
+                scheduler=trial_scheduler,
+                chdir_to_trial_dir=False,
+                **tune_cfg),
             run_config=RunConfig(
                 local_dir=work_dir,
                 stop=stopper,

--- a/siatune/tune/tuner.py
+++ b/siatune/tune/tuner.py
@@ -75,10 +75,7 @@ class Tuner:
             trainable,
             param_space=dict(train_loop_config=param_space),
             tune_config=TuneConfig(
-                search_alg=searcher,
-                scheduler=trial_scheduler,
-                chdir_to_trial_dir=False,
-                **tune_cfg),
+                search_alg=searcher, scheduler=trial_scheduler, **tune_cfg),
             run_config=RunConfig(
                 local_dir=work_dir,
                 stop=stopper,


### PR DESCRIPTION
## Motivation

We need to bump ray to v2.2.0 to support the relative path.
Please refer to this [issue](https://github.com/ray-project/ray/issues/29128) and this [PR](https://github.com/ray-project/ray/pull/29258) for details.

### TODO
- [ ] Test