### PR TITLE
[Enhance] Add support for dict input in Choice

### DIFF
--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -1,5 +1,5 @@
 # Copyright (c) SI-Analytics. All rights reserved.
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, Union
 
 import ray.tune as tune
 from ray.tune.search.sample import Domain
@@ -22,7 +22,7 @@ class Choice(BaseSpace):
     sample: Callable = tune.choice
 
     def __init__(self,
-                 categories: Union[Sequence, Dict] ,
+                 categories: Union[Sequence, dict],
                  alias: Optional[Sequence] = None) -> None:
         if isinstance(categories, dict):
             categories = categories.values()

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -25,8 +25,8 @@ class Choice(BaseSpace):
                  categories: Union[Sequence, dict],
                  alias: Optional[Sequence] = None) -> None:
         if isinstance(categories, dict):
-            categories = categories.values()
             alias = categories.keys()
+            categories = categories.values()
 
         if alias is not None:
             assert isinstance(alias, Sequence)

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -14,9 +14,9 @@ class Choice(BaseSpace):
     """Sample a categorical value.
 
     Args:
-        categories (Sequence): The categories.
-        alias (Sequence, optional): A alias to be expressed.
-            Defaults to None.
+        categories (Sequence | dict): The categories. If categories is dict,
+            keys of dict will override the alias.
+        alias (Sequence, optional): A alias to be expressed. Defaults to None.
     """
 
     sample: Callable = tune.choice
@@ -24,6 +24,10 @@ class Choice(BaseSpace):
     def __init__(self,
                  categories: Sequence,
                  alias: Optional[Sequence] = None) -> None:
+        if isinstance(categories, dict):
+            categories = categories.values()
+            alias = categories.keys()
+
         if alias is not None:
             assert isinstance(alias, Sequence)
             assert len(categories) == len(alias)

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -22,7 +22,7 @@ class Choice(BaseSpace):
     sample: Callable = tune.choice
 
     def __init__(self,
-                 categories: Sequence,
+                 categories: Union[Sequence, Dict] ,
                  alias: Optional[Sequence] = None) -> None:
         if isinstance(categories, dict):
             categories = categories.values()

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -15,7 +15,7 @@ class Choice(BaseSpace):
 
     Args:
         categories (Sequence | dict): The categories. If categories is dict,
-            keys of dict will override the alias.
+            keys of dict will overwrite the alias.
         alias (Sequence, optional): A alias to be expressed. Defaults to None.
     """
 

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -14,9 +14,9 @@ class Choice(BaseSpace):
     """Sample a categorical value.
 
     Args:
-        categories (Sequence | dict): The categories. If categories is dict,
-            keys of dict will overwrite the alias.
-        alias (Sequence, optional): An alias to be expressed. Defaults to None.
+        categories (Sequence | dict): The categorical search space to choose
+            one. If categories is dict, keys of dict will overwrite the alias.
+        alias (Sequence, optional): A alias to be expressed. Defaults to None.
     """
 
     sample: Callable = tune.choice

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -25,8 +25,7 @@ class Choice(BaseSpace):
                  categories: Union[Sequence, dict],
                  alias: Optional[Sequence] = None) -> None:
         if isinstance(categories, dict):
-            alias = categories.keys()
-            categories = categories.values()
+            alias, categories = zip(*[(k, v) for k, v in categories.items()])
 
         if alias is not None:
             assert isinstance(alias, Sequence)

--- a/siatune/tune/spaces/choice.py
+++ b/siatune/tune/spaces/choice.py
@@ -16,7 +16,7 @@ class Choice(BaseSpace):
     Args:
         categories (Sequence | dict): The categories. If categories is dict,
             keys of dict will overwrite the alias.
-        alias (Sequence, optional): A alias to be expressed. Defaults to None.
+        alias (Sequence, optional): An alias to be expressed. Defaults to None.
     """
 
     sample: Callable = tune.choice

--- a/tests/test_tune/test_spaces.py
+++ b/tests/test_tune/test_spaces.py
@@ -33,6 +33,7 @@ def test_choice():
     with pytest.raises(AssertionError):
         choice = Choice(categories=[True, False], alias=['TF'])
     choice = Choice(categories=[True, False], alias=['T', 'F'])
+    choice = Choice(categories=dict(T=True, F=False))
     tune.run(is_immutable, config=dict(test=choice.space))
 
 


### PR DESCRIPTION
### Usage
```python
some = dict(
    type='Choice',
    categories=dict(
        alias1=complicated_obj1,
        alias2=complicated_obj2))

# It is equivalent to the above
some = dict(
    type='Choice',
    categories=[complicated_obj1, complicated_obj2],
    alias=['alias1', 'alias2']))
```